### PR TITLE
Add predicted score to instructor reports

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -9,6 +9,7 @@
 # production
 /build
 /build-prod
+/build-prod-old
 
 # misc
 .DS_Store

--- a/client/package.json
+++ b/client/package.json
@@ -29,7 +29,7 @@
     "build-css": "node-sass-chokidar --include-path ./src --include-path ./node_modules src/ -o src/",
     "watch-css": "npm run build-css && node-sass-chokidar --include-path ./src --include-path ./node_modules src/ -o src/ --watch --recursive",
     "start": "react-scripts start",
-    "build": "react-scripts build  && rm -rf build-prod && mv build build-prod",
+    "build": "react-scripts build  && rm -rf build-prod-old && mv build-prod build-prod-old && mv build build-prod",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
   }

--- a/client/src/components/instructor/AggregatedQuizReview.js
+++ b/client/src/components/instructor/AggregatedQuizReview.js
@@ -206,34 +206,43 @@ class AggregatedQuizReview extends Component {
         const { scores, averageScore, predictedScores, averagePredictedScore, averageWadayanoScore, confidenceAnalysisCounts, conceptAverageScores, conceptAveragePredictedScores, conceptAverageWadayanoScores } = this.state;
 
         const averageScoreLabel = (score) => (
-            <React.Fragment>
+            <div className="is-flex aggregated-score-label">
                 <span className="icon is-medium is-pulled-left has-text-primary">
                     <i className="fas fa-2x fa-chart-bar"></i>
                 </span>
-                <h4 className="subtitle is-inline-block" style={{padding: "0.3rem 0 0 1rem"}}>
-                    Average Score: {formatScore(score)}
+                <h4 className="subtitle is-flex flex-1">
+                    Average Score
                 </h4>
-            </React.Fragment>
+                <h4 className="subtitle is-flex">
+                    {formatScore(score)}
+                </h4>
+            </div>
         );
 
         const averagePredictedScoreLabel = (score) => (
-            <React.Fragment>
+            <div className="is-flex aggregated-score-label">
                 <span className="icon is-medium is-pulled-left has-text-primary">
                     <i className="fas fa-2x fa-chart-line"></i>
                 </span>
-                <h4 className="subtitle is-inline-block" style={{padding: "0.3rem 0 0 1rem"}}>
-                    Average Predicted Score: {formatScore(score)}
+                <h4 className="subtitle is-flex flex-1">
+                    Average Predicted Score
                 </h4>
-            </React.Fragment>
+                <h4 className="subtitle is-flex">
+                    {formatScore(score)}
+                </h4>
+            </div>
         );
 
         const averageWadayanoScoreLabel = (score) => (
-            <React.Fragment>
+            <div className="is-flex aggregated-score-label">
                 <img className="wadayano-list" src={Logo} alt="wadayano logo" style={{height: "2rem"}} />
-                <h4 className="subtitle is-inline-block" style={{padding: "0.3rem 0 0 1rem"}}>
-                    Average Wadayano Score: {formatScore(score)}
+                <h4 className="subtitle is-flex flex-1">
+                    Average Wadayano Score
                 </h4>
-            </React.Fragment>
+                <h4 className="subtitle is-flex">
+                    {formatScore(score)}
+                </h4>
+            </div>
         );
 
         return (
@@ -242,14 +251,12 @@ class AggregatedQuizReview extends Component {
                     <div className="column">
                         <div className="box" style={{height: "280px"}}>
                             {averageScoreLabel(averageScore)}
-                            <br />
                             <ScoresBarGraph scores={scores} />
                         </div>
                     </div>
                     <div className="column">
                         <div className="box" style={{height: "280px"}}>
                             {averageWadayanoScoreLabel(averageWadayanoScore)}
-                            <br />
                             <ConfidenceBarGraph
                                 overconfident={confidenceAnalysisCounts.OVERCONFIDENT}
                                 accurate={confidenceAnalysisCounts.ACCURATE}
@@ -260,10 +267,9 @@ class AggregatedQuizReview extends Component {
                     </div>
                 </div>
                 <div className="columns is-desktop">
-                    <div className="column is-6">
+                    <div className="column is-half-desktop">
                         <div className="box" style={{height: "280px"}}>
                             {averagePredictedScoreLabel(averagePredictedScore)}
-                            <br />
                             <ScoresBarGraph scores={predictedScores} />
                         </div>
                     </div>
@@ -282,9 +288,7 @@ class AggregatedQuizReview extends Component {
                                         <span className="question-count">{questionCount === 1 ? '1 Question' : questionCount + ' Questions'}</span>
                                     </p>
                                     {averageScoreLabel(conceptAverageScores.get(concept))}
-                                    <br style={{clear: "both"}} />
                                     {averagePredictedScoreLabel(conceptAveragePredictedScores.get(concept))}
-                                    <br style={{clear: "both"}} />
                                     {averageWadayanoScoreLabel(conceptAverageWadayanoScores.get(concept))}
                                     {/*<footer className="">
                                         <button className="button is-primary is-block" style={{width: "100%"}} onClick={() => alert('Not yet implemented')}>View Details</button>

--- a/client/src/components/instructor/CourseScores.js
+++ b/client/src/components/instructor/CourseScores.js
@@ -168,7 +168,7 @@ class CourseScores extends Component {
                                                 </button>
                                             </td>
                                         </React.Fragment>
-                                    : <td colSpan="6"><i>Quiz not taken</i></td>
+                                    : <td colSpan="5"><i>Quiz not taken</i></td>
                                     }
                                 </tr>);
                             })}

--- a/client/src/components/instructor/QuizScores.js
+++ b/client/src/components/instructor/QuizScores.js
@@ -7,7 +7,7 @@ import { withAuthCheck } from '../shared/AuthCheck';
 
 import ErrorBox from '../shared/ErrorBox';
 import LoadingBox from '../shared/LoadingBox';
-import { formatScore, wadayanoScore, confidenceAnalysis, stringCompare } from '../../utils';
+import { formatScore, predictedScore, wadayanoScore, confidenceAnalysis, stringCompare } from '../../utils';
 import { QUIZ_TYPE_NAMES } from '../../constants';
 import QuizReviewPage from '../student/QuizReviewPage';
 import AggregatedQuizReview from './AggregatedQuizReview';
@@ -49,6 +49,7 @@ class QuizScores extends Component {
                 } catch (error) { }
                 // Output score for each student, if quiz was taken
                 if (highestAttempt) {
+                    const attemptPredictedScore = predictedScore(highestAttempt);
                     const attemptWadayanoScore = wadayanoScore(highestAttempt);
                     const attemptConfidenceAnalysis = confidenceAnalysis(highestAttempt);
                     return {
@@ -57,6 +58,7 @@ class QuizScores extends Component {
                         attempts: attempts.length,
                         highestScore: highestAttempt.score,
                         highestAttempt,
+                        predictedScore: attemptPredictedScore,
                         wadayanoScore: attemptWadayanoScore,
                         confidenceAnalysis: attemptConfidenceAnalysis
                     }
@@ -125,6 +127,7 @@ class QuizScores extends Component {
                 { title: 'Student Name', columnId: 'name', sortable: true },
                 { title: 'Attempts', columnId: 'attempts', sortable: true },
                 { title: 'Highest Score', columnId: 'highestScore', sortable: true },
+                { title: 'Predicted Score', columnId: 'predictedScore', sortable: true },
                 { title: 'Wadayano Score', columnId: 'wadayanoScore', sortable: true },
                 { title: 'Confidence Analysis', columnId: 'confidenceAnalysis', sortable: true },
                 { title: 'View Report', columnId: 'viewReport', sortable: false }
@@ -153,6 +156,7 @@ class QuizScores extends Component {
                                         <React.Fragment>
                                             <td>{student.attempts}</td>
                                             <td>{formatScore(student.highestScore)}</td>
+                                            <td>{formatScore(student.predictedScore)}</td>
                                             <td>{formatScore(student.wadayanoScore)}</td>
                                             <td>{student.confidenceAnalysis.emoji}&nbsp;{student.confidenceAnalysis.text}</td>
                                             <td>
@@ -253,6 +257,7 @@ const sortFunctions = {
     name: (a, b) => stringCompare(a.name, b.name),
     attempts: (a, b) => a.attempts - b.attempts,
     highestScore: (a, b) => a.highestScore - b.highestScore,
+    predictedScore: (a, b) => a.predictedScore - b.predictedScore,
     wadayanoScore: (a, b) => a.wadayanoScore - b.wadayanoScore,
     confidenceAnalysis: (a, b) => confidenceAnalysisWeights[a.confidenceAnalysis.text] - confidenceAnalysisWeights[b.confidenceAnalysis.text],
 };
@@ -289,6 +294,10 @@ export const QUIZ_QUERY = gql`
                 id
                 isCorrect
                 isConfident
+            }
+            conceptConfidences {
+                id
+                confidence
             }
         }
     }

--- a/client/src/components/instructor/QuizScores.js
+++ b/client/src/components/instructor/QuizScores.js
@@ -169,7 +169,7 @@ class QuizScores extends Component {
                                                 </button>
                                             </td>
                                         </React.Fragment>
-                                    : <td colSpan="5"><i>Quiz not taken</i></td>
+                                    : <td colSpan="6"><i>Quiz not taken</i></td>
                                     }
                                 </tr>);
                             })}

--- a/client/src/styles/Student.css
+++ b/client/src/styles/Student.css
@@ -25,6 +25,10 @@ input[type=radio] {
     -ms-transition: opacity 0.3s ease-in-out;
 }
 
+.flex-1 {
+    flex: 1;
+}
+
 /* Hide firefox dotted focus on buttons */
 button::-moz-focus-inner { 
     border: 0; 
@@ -115,7 +119,7 @@ button::-moz-focus-inner {
 }
 
 /* Quiz Taker */
-progress::-webkit-progress-value {
+progress::-webkit-progress-value, progress::-moz-progress-bar {
     transition: width 0.3s ease-out;
 }
 
@@ -473,6 +477,14 @@ progress::-webkit-progress-value {
  
 	/* Label the data */
 	.responsive-table td:before { content: attr(data-title); }
+}
+
+/* Aggregated report labels */
+.aggregated-score-label {
+    display: flex;
+}
+.aggregated-score-label h4 {
+    padding: 0.3rem 0 0 1rem;
 }
 
 /* Bar graphs */

--- a/client/src/utils.js
+++ b/client/src/utils.js
@@ -22,6 +22,20 @@ export function stripTags(html) {
     return doc.body.textContent || '';
 }
 
+// Calculate predicted score for a given quiz attempt
+// Returns a float ranging from 0 to 1
+export function predictedScore(quizAttempt) {
+    if (!quizAttempt || !quizAttempt.questionAttempts || quizAttempt.questionAttempts.length === 0 || !quizAttempt.conceptConfidences || quizAttempt.conceptConfidences.length === 0) { 
+        return 0;
+    }
+    const questionCount = quizAttempt.questionAttempts.length;
+    // Predicted score is the percentage of questions that the student predicted they would get correct (in the pre-quiz confidence assessment)
+    let predictedCount = 0;
+    quizAttempt.conceptConfidences.forEach(c => predictedCount += c.confidence);
+
+    return (predictedCount / questionCount);
+}
+
 // Calculate wadayano score for a given quiz attempt
 // Returns a float ranging from 0 to 1
 export function wadayanoScore(quizAttempt) {


### PR DESCRIPTION
1. Add predicted score to:
    - Quiz-level student scores table
    - Course-level quiz scores table
    - Aggregated quiz report

![image](https://user-images.githubusercontent.com/9064299/48307009-edf7c980-e500-11e8-9094-6c5c2bc4e2f0.png)
![image](https://user-images.githubusercontent.com/9064299/48307017-14b60000-e501-11e8-92c2-f67da6ac79f1.png)

![image](https://user-images.githubusercontent.com/9064299/48307012-f6e89b00-e500-11e8-8811-f166b09b97f4.png)

2. Tweak build command to keep the previous frontend build backup for fast rollback, if necessary.
