### PR TITLE
Add Actual - Predicted Score graph

### DIFF
--- a/client/src/components/instructor/AggregatedQuizReview.js
+++ b/client/src/components/instructor/AggregatedQuizReview.js
@@ -359,23 +359,31 @@ const AggregatedQuizReview = ({ quizId }) => {
       <div className="columns is-desktop">
         <PageTitle title={`wadayano | ${quiz.title} Class Scores`} />
         <div className="column">
-          <div className="box" style={{ minHeight: '315px' }}>
+          <div className="box" style={{ minHeight: '325px' }}>
             {barGraphLegend}
             {/* Rendering these in a ternary would be cleaner, but causes issues with tooltips */}
             {showCombinedBarGraph && (
-              <ScoresBarGraph
-                scoreSeries={[predictedScoreDifferences]}
-                numBars={11}
-                barColors={['#23d160']}
-                lowerThreshold={-0.5}
-                upperThreshold={0.6}
-              />
+              <>
+                <ScoresBarGraph
+                  scoreSeries={[predictedScoreDifferences]}
+                  numBars={11}
+                  barColors={['#23d160']}
+                  lowerThreshold={-0.5}
+                  upperThreshold={0.6}
+                />
+                <table className="confidence-axis-labels">
+                  <tr>
+                    <td>Underconfident</td>
+                    <td>Overconfident</td>
+                  </tr>
+                </table>
+              </>
             )}
             {!showCombinedBarGraph && <ScoresBarGraph scoreSeries={[predictedScores, scores]} />}
           </div>
         </div>
         <div className="column">
-          <div className="box" style={{ minHeight: '315px' }}>
+          <div className="box" style={{ minHeight: '325px' }}>
             {averageWadayanoScoreLabel(averageWadayanoScore)}
             <ConfidenceBarGraph
               overconfident={confidenceAnalysisCounts.OVERCONFIDENT}

--- a/client/src/components/instructor/ScoresBarGraph.js
+++ b/client/src/components/instructor/ScoresBarGraph.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-array-index-key */
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import ReactTooltip from 'react-tooltip';
 
@@ -10,107 +10,119 @@ const NUM_BARS = 10;
 const MAX_HEIGHT = 210;
 const BAR_COLORS = ['hsl(48, 100%, 67%)', 'hsl(204, 86%, 53%)'];
 
-export default class ScoresBarGraph extends Component {
-  constructor(props) {
-    super(props);
-    const scoreSeriesGroups = props.scoreSeries.map(scores => {
-      scores.sort();
+const ScoresBarGraph = ({
+  scoreSeries,
+  numBars = NUM_BARS,
+  barColors = BAR_COLORS,
+  lowerThreshold = 0,
+  upperThreshold = 1,
+}) => {
+  const scoreSeriesGroups = scoreSeries.map(scores => {
+    scores.sort((a, b) => a - b);
 
-      // Generate random data for demo purposes
-      /*
-            scores = [];
-            for (let i = 0; i < 200; i++) {
-                scores.push(Math.random());
-            }
-            scores.sort();
-            */
+    // Generate random data for demo purposes
+    /*
+    scores = [];
+    for (let i = 0; i < 100; i++) {
+      scores.push(Math.random() > 0.5 ? Math.random() : Math.random() * -1.0);
+    }
+    scores.sort((a, b) => a - b);
+    console.log(scores);
+    */
 
-      const scoreGroups = [];
-      let scoreIndex = 0;
+    const scoreGroups = [];
+    let scoreIndex = 0;
 
-      // Group scores by NUM_BARS (e.g. if 10 bars, group by 10% increments.
-      // Groups exclude upper bound, e.g. 0 ≤ score < 10, but last will include upper bound, 90 ≤ score ≤ 100)
-      for (let i = 0; i < NUM_BARS; i++) {
-        const scoreThreshold = (i + 1) * (1 / NUM_BARS);
-        const previousScoreIndex = scoreIndex;
+    // Group scores by numBars (e.g. if 10 bars, group by 10% increments.
+    // Groups exclude upper bound, e.g. 0 ≤ score < 10, but last will include upper bound, 90 ≤ score ≤ 100)
+    for (let i = 0; i < numBars; i++) {
+      let scoreThreshold = lowerThreshold + (i + 1) * ((upperThreshold - lowerThreshold) / numBars);
+      // Handle exclusion differently when < 0
+      if (scoreThreshold <= 0) {
+        scoreThreshold = lowerThreshold + i * ((upperThreshold - lowerThreshold) / numBars);
+      }
+      const previousScoreIndex = scoreIndex;
 
-        // If not in last group, continue going through scores until next threshold
-        if (i !== NUM_BARS - 1) {
-          while (scores[scoreIndex] < scoreThreshold) {
-            scoreIndex++;
-          }
-        } else {
-          // Otherwise, go to end of array
-          scoreIndex = scores.length;
+      // console.log(i, scoreThreshold, scoreLabel);
+
+      // If not in last group, continue going through scores until next threshold
+      if (i !== numBars - 1) {
+        while (scores[scoreIndex] < scoreThreshold) {
+          // console.log('\t adding score ', scores[scoreIndex]);
+          scoreIndex++;
         }
-
-        // There are (scoreIndex - previousScoreIndex) many scores in this group
-        scoreGroups.push(scoreIndex - previousScoreIndex);
+      } else {
+        // Otherwise, go to end of array
+        scoreIndex = scores.length;
+        // console.log('\t adding the rest of the scores');
       }
 
-      return scoreGroups;
-    });
-
-    this.state = {
-      scoreSeriesGroups,
-    };
-  }
-
-  render() {
-    const { scoreSeriesGroups } = this.state;
-
-    // Determine count for largest bar (find largest value in any of the series)
-    // I know serie isn't a word, but I'm using it as singular and series as plural to be clearer
-    const max = Math.max(
-      ...scoreSeriesGroups.map(scoreSerieGroups => Math.max(...scoreSerieGroups))
-    );
-
-    const barCells = [];
-    for (let i = 0; i < NUM_BARS; i++) {
-      barCells[i] = (
-        <td key={i}>
-          {scoreSeriesGroups.map((scoreSerieGroups, serieIndex) => (
-            <span
-              key={serieIndex}
-              className="chart-bar"
-              style={{
-                height: `${(scoreSerieGroups[i] / max) * MAX_HEIGHT}px`,
-                backgroundColor: BAR_COLORS[serieIndex],
-              }}
-              data-tip={
-                scoreSerieGroups[i] + (scoreSerieGroups[i] === 1 ? ' student' : ' students')
-              }
-            />
-          ))}
-        </td>
-      );
+      // There are (scoreIndex - previousScoreIndex) many scores in this group
+      scoreGroups.push(scoreIndex - previousScoreIndex);
     }
 
-    return (
-      <>
-        <table className="scores-bar-graph">
-          <tbody>
-            <tr>{barCells}</tr>
-            <tr className="tick-mark-labels">
-              {barCells.map((unused, index) => (
-                <td key={index}>{formatScore(index * (1 / NUM_BARS))} </td>
-              ))}
-            </tr>
-            <tr className="tick-marks">
-              {barCells.map((unused, index) => (
-                <td key={index}> {/* Placeholder cell for tickmarks */} </td>
-              ))}
-            </tr>
-          </tbody>
-        </table>
-        <ReactTooltip />
-      </>
+    return scoreGroups;
+  });
+
+  // Determine count for largest bar (find largest value in any of the series)
+  // I know serie isn't a word, but I'm using it as singular and series as plural to be clearer
+  const max = Math.max(...scoreSeriesGroups.map(scoreSerieGroups => Math.max(...scoreSerieGroups)));
+
+  const barCells = [];
+  const barLabels = [];
+  for (let i = 0; i < numBars; i++) {
+    barLabels[i] = formatScore(lowerThreshold + i * ((upperThreshold - lowerThreshold) / numBars));
+    barCells[i] = (
+      <td key={i}>
+        {scoreSeriesGroups.map((scoreSerieGroups, serieIndex) => (
+          <span
+            key={serieIndex}
+            className="chart-bar"
+            style={{
+              height: `${(scoreSerieGroups[i] / max) * MAX_HEIGHT}px`,
+              backgroundColor: barColors[serieIndex],
+            }}
+            data-tip={scoreSerieGroups[i] + (scoreSerieGroups[i] === 1 ? ' student' : ' students')}
+          />
+        ))}
+      </td>
     );
   }
-}
+
+  return (
+    <>
+      <table className="scores-bar-graph">
+        <tbody>
+          <tr>{barCells}</tr>
+          <tr className="tick-mark-labels">
+            {barLabels.map(label => (
+              <td key={label} style={{ width: `${(1 / numBars) * 100}%` }}>
+                {label}
+              </td>
+            ))}
+          </tr>
+          <tr className="tick-marks">
+            {barLabels.map(label => (
+              <td key={label}> {/* Placeholder cell for tickmarks */} </td>
+            ))}
+          </tr>
+        </tbody>
+      </table>
+      <ReactTooltip />
+    </>
+  );
+};
 
 ScoresBarGraph.propTypes = {
   // E.g. [ [1,2,3], [1,4,2] ] for a 2-series graph
   scoreSeries: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number.isRequired).isRequired)
     .isRequired,
+  numBars: PropTypes.number,
+  barColors: PropTypes.arrayOf(PropTypes.string.isRequired),
+  lowerThreshold: PropTypes.number,
+  upperThreshold: PropTypes.number,
 };
+
+// The props to this won't change often, so memoize it.
+// Calculation is done in the render method, as suggested in https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#what-about-memoization
+export default React.memo(ScoresBarGraph);

--- a/client/src/styles/Instructor.css
+++ b/client/src/styles/Instructor.css
@@ -307,6 +307,10 @@
 .scores-bar-graph-legend h4 {
     padding-right: 0.5rem;
 }
+.scores-bar-graph-legend button {
+    margin-top: -0.5rem;
+    margin-right: -0.5rem;
+}
 
 /* Aggregated confidence analysis bar graph */
 .confidence-bar-graph td {

--- a/client/src/styles/Instructor.css
+++ b/client/src/styles/Instructor.css
@@ -258,7 +258,7 @@
     margin-bottom: -0.4rem!important;
 }
 .scores-bar-graph td {
-    text-align: center;
+    text-align: center!important;
     vertical-align: bottom!important;
     border-bottom: none!important;
     border-top: none!important;

--- a/client/src/styles/Instructor.css
+++ b/client/src/styles/Instructor.css
@@ -300,10 +300,6 @@
     padding: 0.5rem 0 0 1rem!important;
     text-align: center!important;
 }
-.confidence-axis-labels td:last-of-type {
-    /* text-align: right; */
-    /* padding: 0.5rem 1rem 0 0!important; */
-}
 .scores-bar-graph-legend h4 {
     padding-right: 0.5rem;
 }

--- a/client/src/styles/Instructor.css
+++ b/client/src/styles/Instructor.css
@@ -291,6 +291,19 @@
     padding: 0;
     font-size: 50%;
 }
+.confidence-axis-labels {
+    margin: -0.5rem 0 -1rem 0;
+}
+.confidence-axis-labels td {
+    border: none!important;
+    font-size: 60%;
+    padding: 0.5rem 0 0 1rem!important;
+    text-align: center!important;
+}
+.confidence-axis-labels td:last-of-type {
+    /* text-align: right; */
+    /* padding: 0.5rem 1rem 0 0!important; */
+}
 .scores-bar-graph-legend h4 {
     padding-right: 0.5rem;
 }


### PR DESCRIPTION
This implements feature request 1, as discussed with Bob.

### Preview Deploy
https://actual-minus-predicted-graph-wadayano-preview.surge.sh/

### Changes
* Add a separate graph (that can be toggled between) to the aggregated quiz review page.
* This graph contains the (actual - predicted) score, i.e., the difference between the student's actual score from their first attempt on the quiz and their predicted score for that attempt. 
* This required reworking a lot of the `ScoresBarGraph` component to handle the different thresholds, etc.
* This can be tweaked, but for me it made sense to: have negative percentages include things lower than that, and the positive percentages to include things higher than that. (E.g., -25% is in the -20% bar, and 25% is in the 20% bar). But this means 0 contains the range (-10%, 10%) which might be a little confusing. But maybe less confusing than -25% being in the -30% bar? Let me know what you think :)

### Screenshots
![image](https://user-images.githubusercontent.com/9064299/69906108-8adf0c00-137b-11ea-90ed-2e9b79c5b1ae.png)

![image](https://user-images.githubusercontent.com/9064299/69906107-8581c180-137b-11ea-9716-7a7d46f2cc63.png)
